### PR TITLE
Fix NotSym

### DIFF
--- a/src/GHC/TypeLits/Printf/Internal/Parser.hs
+++ b/src/GHC/TypeLits/Printf/Internal/Parser.hs
@@ -31,7 +31,7 @@ type instance RunParser (Sym c) (d ': cs) = If (c == d) ('Just '(c, cs)) 'Nothin
 type instance RunParser (Sym c) '[]       = 'Nothing
 
 data NotSym :: SChar -> Parser SChar
-type instance RunParser (NotSym c) (d ': cs) = If (c == d) 'Nothing ('Just '(c, cs))
+type instance RunParser (NotSym c) (d ': cs) = If (c == d) 'Nothing ('Just '(d, cs))
 type instance RunParser (NotSym c) '[]       = 'Nothing
 
 data AnySym :: Parser SChar


### PR DESCRIPTION
The `NotSym` case in `RunParser` returns the ignored character instead of the
parsed character, resulting in the following:

``` haskell
ghci> putStrLn $ printf @"You have %.2f dollars, %s" 3.62 "Luigi"
%%%%%%%%%3.62%%%%%%%%%%Luigi
```

I flipped it around, so now it correctly parses as:

``` haskell
ghci> putStrLn $ printf @"You have %.2f dollars, %s" 3.62 "Luigi"
You have 3.62 dollars, Luigi
```