### PR TITLE
Better type feedback for printf (satisfies all three benefits)

### DIFF
--- a/src/GHC/TypeLits/Printf/Internal.hs
+++ b/src/GHC/TypeLits/Printf/Internal.hs
@@ -386,7 +386,7 @@ newtype PHelp = PHelp {
     pHelp :: String
   }
 
-instance (a ~ Char) => FormatFun '[] [a] where
+instance {-# INCOHERENT #-} (a ~ String) => FormatFun '[] a where
     formatFun _ = id
 instance (a ~ Char) => FormatFun '[] PHelp where
     formatFun _ = PHelp
@@ -414,7 +414,7 @@ instance TypeError ( 'Text "An extra argument of type "
 instance (KnownSymbol str, FormatFun ffs fun) => FormatFun ('Left str ': ffs) fun where
     formatFun _ str = formatFun (Proxy @ffs) (str ++ symbolVal (Proxy @str))
 
-instance (Reflect ff, ff ~ 'FF f w p m c, FormatType c a, FormatFun ffs fun) => FormatFun ('Right ff ': ffs) (a -> fun) where
+instance {-# INCOHERENT #-} (afun ~ (arg -> fun), Reflect ff, ff ~ 'FF f w p m c, FormatType c arg, FormatFun ffs fun) => FormatFun ('Right ff ': ffs) afun where
     formatFun _ str x = formatFun (Proxy @ffs) (str ++ formatArg (Proxy @c) x ff "")
       where
         ff = reflect (Proxy @ff)
@@ -460,7 +460,7 @@ newtype PFmt c = PFmt P.FieldFormat
 
 -- | A version of 'mkPFmt' that takes an explicit proxy input.
 --
--- >>> pfmt (mkPFmt_ (Proxy :: Proxy ".2f") 3.6234124
+-- >>> pfmt (mkPFmt_ (Proxy :: Proxy ".2f")) 3.6234124
 -- "3.62"
 mkPFmt_
     :: forall str lst ff f w q m c p. (Listify str lst, ff ~ ParseFmt_ lst, Reflect ff, ff ~ 'FF f w q m c)

--- a/src/GHC/TypeLits/Printf/Internal/Parser.hs
+++ b/src/GHC/TypeLits/Printf/Internal/Parser.hs
@@ -31,7 +31,7 @@ type instance RunParser (Sym c) (d ': cs) = If (c == d) ('Just '(c, cs)) 'Nothin
 type instance RunParser (Sym c) '[]       = 'Nothing
 
 data NotSym :: SChar -> Parser SChar
-type instance RunParser (NotSym c) (d ': cs) = If (c == d) 'Nothing ('Just '(c, cs))
+type instance RunParser (NotSym c) (d ': cs) = If (c == d) 'Nothing ('Just '(d, cs))
 type instance RunParser (NotSym c) '[]       = 'Nothing
 
 data AnySym :: Parser SChar


### PR DESCRIPTION
I quickly drafted this as an idea, and I haven't carefully verified
that it works in all situations, but it does on the examples at least.

``` haskell
ghci> :t printf @"You have %.2f dollars, %s"
(FormatType "f" arg1, FormatType "s" arg2) => arg1 -> arg2 -> String
```

The idea is to use `INCOHERENT` instances to default to the right
instance when no concrete type information is known about the
arguments.

In partcular, when the result type is not specified, this will default
to `String`, and when there is a `Right` at the front of the list and
the result type is unknown, we infer that it should be a function.

Let me know what you think! I think this is a safe use of incoherent
instances, because essentially we only drive type inference.